### PR TITLE
Add GitHub Actions CI/CD with fuzz testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22', '1.23']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ matrix.go-version }}-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
+
+    - name: Run tests
+      run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.out
+        flags: unittests
+        name: codecov-umbrella
+      continue-on-error: true
+
+  fuzz:
+    name: Fuzz Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-fuzz-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-fuzz-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run fuzz tests
+      run: |
+        # Run each fuzz test for 30 seconds
+        go test -fuzz=FuzzReadWriteSmall -fuzztime=30s -v ./...
+        go test -fuzz=FuzzReadWriteLarge -fuzztime=30s -v ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+        args: --timeout=5m
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: Build
+      run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,0 @@
-version: "2"
-
-linters-settings:
-  staticcheck:
-    checks: ["all", "-QF1008"]  # Disable QF1008 (embedded field selector suggestion)
-
-run:
-  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters-settings:
+  staticcheck:
+    checks: ["all", "-QF1008"]  # Disable QF1008 (embedded field selector suggestion)
+
+run:
+  timeout: 5m

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/eliothedeman/cryptio.svg?style=svg)](https://circleci.com/gh/eliothedeman/cryptio)
+[![CI](https://github.com/eliothedeman/cryptio/actions/workflows/ci.yml/badge.svg)](https://github.com/eliothedeman/cryptio/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/eliothedeman/cryptio)](https://goreportcard.com/report/github.com/eliothedeman/cryptio)
 [![GoDoc](https://godoc.org/github.com/eliothedeman/cryptio?status.svg)](https://godoc.org/github.com/eliothedeman/cryptio)
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,143 @@
+package cryptio
+
+import (
+	"bytes"
+	"crypto/aes"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// FuzzReadWriteSmall tests ReadWriteSeeker with small data (< block size)
+func FuzzReadWriteSmall(f *testing.F) {
+	// Seed corpus with some initial test cases
+	f.Add([]byte("hello"), []byte("1234567890123456")) // 16-byte key for AES-128
+	f.Add([]byte("test"), []byte("12345678901234567890123456789012")) // 32-byte key for AES-256
+	f.Add([]byte("a"), []byte("123456789012345678901234")) // 24-byte key for AES-192
+	f.Add([]byte(""), []byte("1234567890123456"))
+
+	f.Fuzz(func(t *testing.T, data []byte, key []byte) {
+		// Ensure key is valid AES size (16, 24, or 32 bytes)
+		if len(key) != 16 && len(key) != 24 && len(key) != 32 {
+			t.Skip("Invalid key size")
+		}
+
+		// Skip if data is too large for small test
+		if len(data) >= 32 {
+			t.Skip("Data too large for small test")
+		}
+
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			t.Skip("Failed to create cipher")
+		}
+
+		// Create temp file for testing
+		tmpFile, err := ioutil.TempFile("", "fuzz_test_*")
+		if err != nil {
+			t.Skip("Failed to create temp file")
+		}
+		defer os.Remove(tmpFile.Name())
+		defer tmpFile.Close()
+
+		// Create ReadWriteSeeker
+		rws := ReadWriteSeeker(tmpFile, block)
+
+		// Write data
+		n, err := rws.Write(data)
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+		if n != len(data) {
+			t.Fatalf("Write returned %d, expected %d", n, len(data))
+		}
+
+		// Seek back to beginning
+		_, err = rws.Seek(0, 0)
+		if err != nil {
+			t.Fatalf("Seek failed: %v", err)
+		}
+
+		// Read data back
+		got := make([]byte, len(data))
+		if len(data) > 0 {
+			n, err = io.ReadFull(rws, got)
+			if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+				t.Fatalf("Read failed: %v", err)
+			}
+		}
+
+		// Verify round-trip
+		if !bytes.Equal(data, got) {
+			t.Fatalf("Round-trip failed:\noriginal:  % x\ndecrypted: % x", data, got)
+		}
+	})
+}
+
+// FuzzReadWriteLarge tests ReadWriteSeeker with larger data
+func FuzzReadWriteLarge(f *testing.F) {
+	// Seed corpus
+	f.Add([]byte("this is a longer test string with more data"), []byte("1234567890123456"))
+	f.Add([]byte("testing with random bytes and longer content"), []byte("12345678901234567890123456789012"))
+	f.Add(make([]byte, 100), []byte("1234567890123456"))
+
+	f.Fuzz(func(t *testing.T, data []byte, key []byte) {
+		// Ensure key is valid AES size
+		if len(key) != 16 && len(key) != 24 && len(key) != 32 {
+			t.Skip("Invalid key size")
+		}
+
+		// Skip empty data
+		if len(data) == 0 {
+			t.Skip("Empty data")
+		}
+
+		// Limit data size to keep fuzzing fast (but still test larger sizes)
+		if len(data) > 1024 {
+			data = data[:1024]
+		}
+
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			t.Skip("Failed to create cipher")
+		}
+
+		// Create temp file
+		tmpFile, err := ioutil.TempFile("", "fuzz_test_*")
+		if err != nil {
+			t.Skip("Failed to create temp file")
+		}
+		defer os.Remove(tmpFile.Name())
+		defer tmpFile.Close()
+
+		// Create ReadWriteSeeker
+		rws := ReadWriteSeeker(tmpFile, block)
+
+		// Write data
+		n, err := rws.Write(data)
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+		if n != len(data) {
+			t.Fatalf("Write returned %d, expected %d", n, len(data))
+		}
+
+		// Seek back
+		_, err = rws.Seek(0, 0)
+		if err != nil {
+			t.Fatalf("Seek failed: %v", err)
+		}
+
+		// Read back
+		got, err := io.ReadAll(rws)
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+
+		if !bytes.Equal(data, got) {
+			t.Fatalf("Data mismatch (len=%d vs %d)", len(data), len(got))
+		}
+	})
+}
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/eliothedeman/cryptio
+
+go 1.24.7
+
+require github.com/eliothedeman/randutil v0.0.0-20160424030750-f83d462f0ca7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/eliothedeman/randutil v0.0.0-20160424030750-f83d462f0ca7 h1:g6QSbUsL0OvGmI3EzMZeBZpgDjzF98yilrtAn9TCA6U=
+github.com/eliothedeman/randutil v0.0.0-20160424030750-f83d462f0ca7/go.mod h1:oiFoQ5KCMx/WkqfdjRziAbeUVJdyuYIX5XF+waGDAHE=

--- a/io.go
+++ b/io.go
@@ -6,8 +6,6 @@ import (
 	"io"
 )
 
-var internalBufferSize = 1024
-
 // buffer for encrypting and decrypting data
 type buffer struct {
 	offset   int64
@@ -38,7 +36,7 @@ func (s *seeker) Seek(offset int64, whence int) (int64, error) {
 
 	n, err := s.source.Seek(offset, whence)
 	if err == nil {
-		s.buffer.offset = offset
+		s.offset = offset
 	}
 
 	return n, nil

--- a/io_test.go
+++ b/io_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ func randBlock(t testing.TB, size int) cipher.Block {
 
 func tmpFile(t testing.TB) *os.File {
 	t.Helper()
-	f, err := ioutil.TempFile(os.TempDir(), strings.Replace(t.Name(), "/", "_", -1))
+	f, err := os.CreateTemp(os.TempDir(), strings.ReplaceAll(t.Name(), "/", "_"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +42,10 @@ func TestReadSmall(t *testing.T) {
 	}
 
 	got := make([]byte, len(want))
-	r.Seek(0, 0)
+	_, err = r.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = r.Read(got)
 	if err != nil {
@@ -69,7 +71,10 @@ func TestReadLarge(t *testing.T) {
 	}
 
 	got := make([]byte, len(want))
-	r.Seek(0, 0)
+	_, err = r.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = r.Read(got)
 	if err != nil {
@@ -106,7 +111,7 @@ func BenchmarkWrite(b *testing.B) {
 	buff := randutil.Bytes(1024)
 	b.Run("1024", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			r.Write(buff)
+			_, _ = r.Write(buff)
 		}
 	})
 	x = randBlock(b, 32)
@@ -115,7 +120,7 @@ func BenchmarkWrite(b *testing.B) {
 	buff = randutil.Bytes(32)
 	b.Run("32", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			r.Write(buff)
+			_, _ = r.Write(buff)
 		}
 	})
 }


### PR DESCRIPTION
- Migrate from CircleCI to GitHub Actions
- Initialize Go modules with go.mod
- Add comprehensive fuzz testing for crypto operations
- Update README badge to show GitHub Actions status
- Test matrix includes Go 1.21, 1.22, and 1.23
- Add fuzz tests for small and large data encryption/decryption
- Include linting and code coverage reporting